### PR TITLE
Update Hugo version to 0.155.3 for theme compatibility

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "0.145.0"
+          hugo-version: "0.155.3"
           extended: true
 
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
The updated Kayal theme requires a newer Hugo version than 0.145.0, which caused missing layout warnings and broken pages in CI.