### PR TITLE
Add release notes generation for two additional projects

### DIFF
--- a/release-notes-as-posts.sh
+++ b/release-notes-as-posts.sh
@@ -48,3 +48,5 @@ release-notes-as-posts textlint-rule-link-title-case
 release-notes-as-posts wints '2024' # Before 2024, the release was not created at the same time as the tag
 release-notes-as-posts github-actions-toolbox
 release-notes-as-posts agent-skills
+release-notes-as-posts bassin-minier-unesco
+release-notes-as-posts leaflet-atlas


### PR DESCRIPTION
## Summary
This change extends the release notes generation script to include two additional projects: `bassin-minier-unesco` and `leaflet-atlas`.

## Changes
- Added `bassin-minier-unesco` to the list of projects for which release notes are generated as posts
- Added `leaflet-atlas` to the list of projects for which release notes are generated as posts

## Details
These projects are now included in the automated release notes processing pipeline, allowing their release information to be converted into blog post format alongside the other managed projects.

https://claude.ai/code/session_01PQ4Tf3ouvkES5Scxhc2Hiz