### PR TITLE
feat(posts): add choosing-prompt-cache-tier post

### DIFF
--- a/assets/img/posts/choosing-prompt-cache-tier/break-even.svg
+++ b/assets/img/posts/choosing-prompt-cache-tier/break-even.svg
@@ -1,0 +1,92 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" font-family="-apple-system, 'Helvetica Neue', sans-serif">
+  <rect width="800" height="420" fill="#0f172a" rx="8"/>
+
+  <!-- Title -->
+  <text x="400" y="35" text-anchor="middle" font-size="15" fill="#e2e8f0" font-weight="600">Cumulative Cost by Number of Cache Reads</text>
+  <text x="400" y="55" text-anchor="middle" font-size="11" fill="#64748b">Expressed as multiples of base input price for the cached block</text>
+
+  <!-- Chart area -->
+  <g transform="translate(80, 75)">
+    <!-- Y axis -->
+    <line x1="0" y1="0" x2="0" y2="280" stroke="#334155" stroke-width="1.5"/>
+    <!-- X axis -->
+    <line x1="0" y1="280" x2="640" y2="280" stroke="#334155" stroke-width="1.5"/>
+
+    <!-- Y axis labels -->
+    <text x="-10" y="284" text-anchor="end" font-size="10" fill="#64748b">0x</text>
+    <text x="-10" y="228" text-anchor="end" font-size="10" fill="#64748b">2x</text>
+    <text x="-10" y="172" text-anchor="end" font-size="10" fill="#64748b">4x</text>
+    <text x="-10" y="116" text-anchor="end" font-size="10" fill="#64748b">6x</text>
+    <text x="-10" y="60" text-anchor="end" font-size="10" fill="#64748b">8x</text>
+    <text x="-10" y="4" text-anchor="end" font-size="10" fill="#64748b">10x</text>
+
+    <!-- Y gridlines -->
+    <line x1="0" y1="224" x2="640" y2="224" stroke="#1e293b" stroke-width="1"/>
+    <line x1="0" y1="168" x2="640" y2="168" stroke="#1e293b" stroke-width="1"/>
+    <line x1="0" y1="112" x2="640" y2="112" stroke="#1e293b" stroke-width="1"/>
+    <line x1="0" y1="56" x2="640" y2="56" stroke="#1e293b" stroke-width="1"/>
+    <line x1="0" y1="0" x2="640" y2="0" stroke="#1e293b" stroke-width="1"/>
+
+    <!-- X axis labels (reads) -->
+    <text x="0" y="300" text-anchor="middle" font-size="10" fill="#64748b">0</text>
+    <text x="80" y="300" text-anchor="middle" font-size="10" fill="#64748b">1</text>
+    <text x="160" y="300" text-anchor="middle" font-size="10" fill="#64748b">2</text>
+    <text x="240" y="300" text-anchor="middle" font-size="10" fill="#64748b">3</text>
+    <text x="320" y="300" text-anchor="middle" font-size="10" fill="#64748b">4</text>
+    <text x="400" y="300" text-anchor="middle" font-size="10" fill="#64748b">5</text>
+    <text x="480" y="300" text-anchor="middle" font-size="10" fill="#64748b">6</text>
+    <text x="560" y="300" text-anchor="middle" font-size="10" fill="#64748b">7</text>
+    <text x="640" y="300" text-anchor="middle" font-size="10" fill="#64748b">8</text>
+    <text x="320" y="325" text-anchor="middle" font-size="11" fill="#94a3b8">Cache reads within window</text>
+
+    <!-- No caching line (red) - slope: 1x per read, starts at 1x -->
+    <!-- 0: 1x=252, 1: 2x=224, 2: 3x=196, 3: 4x=168, 4: 5x=140, 5: 6x=112, 6: 7x=84, 7: 8x=56, 8: 9x=28 -->
+    <polyline
+      points="0,252 80,224 160,196 240,168 320,140 400,112 480,84 560,56 640,28"
+      fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- 5-minute line (blue) - write=1.25x, then +0.1x per read -->
+    <!-- 0: 1.25x=244.5, 1: 1.35x=241.7, 2: 1.45x=239.4, 3: 1.55x=236.6, 4: 1.65x=233.8, 5: 1.75x=231, 6: 1.85x=228.2, 7: 1.95x=225.4, 8: 2.05x=222.6 -->
+    <polyline
+      points="0,245 80,242 160,239 240,236 320,234 400,231 480,228 560,225 640,223"
+      fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- 1-hour line (amber) - write=2x, then +0.1x per read -->
+    <!-- 0: 2x=224, 1: 2.1x=220.8, 2: 2.2x=218.4, 3: 2.3x=215.6, 4: 2.4x=212.8, 5: 2.5x=210, 6: 2.6x=207.2, 7: 2.7x=204.4, 8: 2.8x=201.6 -->
+    <polyline
+      points="0,224 80,221 160,218 240,216 320,213 400,210 480,207 560,204 640,202"
+      fill="none" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+    <!-- Break-even markers -->
+    <!-- 5m break-even at 1 read -->
+    <circle cx="80" cy="242" r="5" fill="#3b82f6" stroke="#0f172a" stroke-width="2"/>
+    <!-- 1h break-even at 2 reads -->
+    <circle cx="160" cy="218" r="5" fill="#f59e0b" stroke="#0f172a" stroke-width="2"/>
+
+    <!-- Break-even annotations -->
+    <g transform="translate(90, 255)">
+      <rect x="-2" y="-10" width="70" height="16" rx="3" fill="#0f172a" opacity="0.8"/>
+      <text x="0" y="2" font-size="9" fill="#93c5fd">5m break-even</text>
+    </g>
+    <g transform="translate(170, 228)">
+      <rect x="-2" y="-10" width="70" height="16" rx="3" fill="#0f172a" opacity="0.8"/>
+      <text x="0" y="2" font-size="9" fill="#fcd34d">1h break-even</text>
+    </g>
+  </g>
+
+  <!-- Legend -->
+  <g transform="translate(220, 385)">
+    <line x1="0" y1="0" x2="20" y2="0" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>
+    <text x="26" y="4" font-size="11" fill="#94a3b8">No caching</text>
+
+    <g transform="translate(130, 0)">
+      <line x1="0" y1="0" x2="20" y2="0" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="26" y="4" font-size="11" fill="#94a3b8">5-min cache</text>
+    </g>
+
+    <g transform="translate(270, 0)">
+      <line x1="0" y1="0" x2="20" y2="0" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round"/>
+      <text x="26" y="4" font-size="11" fill="#94a3b8">1-hour cache</text>
+    </g>
+  </g>
+</svg>

--- a/assets/img/posts/choosing-prompt-cache-tier/decision-flow.svg
+++ b/assets/img/posts/choosing-prompt-cache-tier/decision-flow.svg
@@ -1,0 +1,91 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" font-family="-apple-system, 'Helvetica Neue', sans-serif">
+  <rect width="800" height="400" fill="#0f172a" rx="8"/>
+
+  <!-- Title -->
+  <text x="400" y="35" text-anchor="middle" font-size="15" fill="#e2e8f0" font-weight="600">Which Cache Tier Should You Use?</text>
+
+  <!-- Question 1: Reuse? -->
+  <g transform="translate(320, 60)">
+    <polygon points="80,0 160,45 80,90 0,45" fill="#1e293b" stroke="#a855f7" stroke-width="2"/>
+    <text x="80" y="40" text-anchor="middle" font-size="10" fill="#c084fc">Will the context</text>
+    <text x="80" y="53" text-anchor="middle" font-size="10" fill="#c084fc">be reused?</text>
+  </g>
+
+  <!-- No reuse -> skip caching -->
+  <!-- Diamond left point at (320, 105). Arrow from there to box right edge at (200, 105). -->
+  <line x1="320" y1="105" x2="208" y2="105" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="208,108 200,105 208,102" fill="#475569"/>
+  <text x="265" y="97" text-anchor="middle" font-size="9" fill="#64748b">No</text>
+
+  <g transform="translate(50, 80)">
+    <rect width="150" height="50" rx="10" fill="#1e293b" stroke="#475569" stroke-width="1.5"/>
+    <text x="75" y="22" text-anchor="middle" font-size="11" fill="#94a3b8">Skip caching</text>
+    <text x="75" y="38" text-anchor="middle" font-size="9" fill="#64748b">Pay base input each time</text>
+  </g>
+
+  <!-- Yes -> Question 2 -->
+  <!-- Diamond bottom point at (400, 150). Q2 top point at (400, 188). -->
+  <line x1="400" y1="150" x2="400" y2="188" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="397,188 400,196 403,188" fill="#475569"/>
+  <text x="410" y="172" font-size="9" fill="#64748b">Yes</text>
+
+  <!-- Question 2: Frequency -->
+  <g transform="translate(320, 188)">
+    <polygon points="80,0 160,45 80,90 0,45" fill="#1e293b" stroke="#a855f7" stroke-width="2"/>
+    <text x="80" y="38" text-anchor="middle" font-size="10" fill="#c084fc">More than 2 reads</text>
+    <text x="80" y="52" text-anchor="middle" font-size="10" fill="#c084fc">within 1 hour?</text>
+  </g>
+
+  <!-- No (<=2 reads) -> 5-minute -->
+  <!-- Diamond left point at (320, 233). Box right edge at (200, 233). -->
+  <line x1="320" y1="233" x2="208" y2="233" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="208,236 200,233 208,230" fill="#475569"/>
+  <text x="265" y="225" text-anchor="middle" font-size="9" fill="#64748b">No</text>
+
+  <!-- 5-minute result box (center-y = 233) -->
+  <g transform="translate(30, 200)">
+    <rect width="170" height="66" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+    <text x="85" y="22" text-anchor="middle" font-size="13" fill="#93c5fd" font-weight="bold">5-minute cache</text>
+    <text x="85" y="38" text-anchor="middle" font-size="9" fill="#64748b">1.25x write, lower risk</text>
+    <text x="85" y="54" text-anchor="middle" font-size="8" fill="#3b82f6" font-family="monospace">{ "type": "ephemeral" }</text>
+  </g>
+
+  <!-- Yes (>2 reads) -> Question 3 -->
+  <!-- Diamond bottom point at (400, 278). Q3 top point at (400, 316). -->
+  <line x1="400" y1="278" x2="400" y2="316" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="397,316 400,324 403,316" fill="#475569"/>
+  <text x="410" y="300" font-size="9" fill="#64748b">Yes</text>
+
+  <!-- Question 3: Stable context? -->
+  <g transform="translate(320, 316)">
+    <polygon points="80,0 160,35 80,70 0,35" fill="#1e293b" stroke="#a855f7" stroke-width="2"/>
+    <text x="80" y="30" text-anchor="middle" font-size="10" fill="#c084fc">Stable context?</text>
+    <text x="80" y="44" text-anchor="middle" font-size="10" fill="#c084fc">(rarely changes)</text>
+  </g>
+
+  <!-- No (unstable) -> 5-minute -->
+  <!-- Diamond left point at (320, 351). Box right edge at (200, 351). -->
+  <line x1="320" y1="351" x2="208" y2="351" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="208,354 200,351 208,348" fill="#475569"/>
+  <text x="265" y="343" text-anchor="middle" font-size="9" fill="#64748b">No</text>
+
+  <!-- Dashed 5-minute box (center-y = 351) -->
+  <g transform="translate(30, 326)">
+    <rect width="170" height="50" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="4,3"/>
+    <text x="85" y="22" text-anchor="middle" font-size="11" fill="#93c5fd">5-minute cache</text>
+    <text x="85" y="38" text-anchor="middle" font-size="9" fill="#64748b">Context changes invalidate anyway</text>
+  </g>
+
+  <!-- Yes (stable) -> 1-hour -->
+  <!-- Diamond right point at (480, 351). Box left edge at (570, 351). -->
+  <line x1="480" y1="351" x2="562" y2="351" stroke="#475569" stroke-width="1.5"/>
+  <polygon points="562,348 570,351 562,354" fill="#475569"/>
+  <text x="522" y="343" text-anchor="middle" font-size="9" fill="#64748b">Yes</text>
+
+  <!-- 1-hour result box (center-y = 351) -->
+  <g transform="translate(570, 326)">
+    <rect width="190" height="50" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+    <text x="95" y="22" text-anchor="middle" font-size="13" fill="#fcd34d" font-weight="bold">1-hour cache</text>
+    <text x="95" y="38" text-anchor="middle" font-size="8" fill="#f59e0b" font-family="monospace">{ ..., "ttl": "1h" }</text>
+  </g>
+</svg>

--- a/assets/img/posts/choosing-prompt-cache-tier/featured.svg
+++ b/assets/img/posts/choosing-prompt-cache-tier/featured.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="-apple-system, 'Helvetica Neue', sans-serif">
+  <rect width="800" height="500" fill="#0f172a" rx="12"/>
+
+  <!-- Title -->
+  <text x="400" y="50" text-anchor="middle" font-size="18" fill="#e2e8f0" font-weight="bold">Prompt Cache Write Tiers</text>
+  <text x="400" y="72" text-anchor="middle" font-size="12" fill="#64748b">Choose the right duration for your workload</text>
+
+  <!-- Layout: left box x=80 w=280 (right edge 360), right box x=420 w=280 (left edge 420)
+       Gap center: (360+420)/2 = 390. But 80+280=360, 800-80-280=440, so right box at 440.
+       Symmetric: left at 60, right at 460, both w=280 → edges 340 and 460, center 400.
+       Better: left at 70, right at 450, w=280 → edges 350 and 450, center 400. -->
+
+  <!-- 5-minute tier (left) -->
+  <g transform="translate(70, 95)">
+    <rect width="280" height="330" rx="12" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+
+    <!-- Clock icon -->
+    <g transform="translate(120, 25)">
+      <circle cx="20" cy="20" r="18" fill="none" stroke="#3b82f6" stroke-width="2.5"/>
+      <line x1="20" y1="20" x2="20" y2="9" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="20" y1="20" x2="28" y2="20" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="20" cy="20" r="2.5" fill="#3b82f6"/>
+    </g>
+
+    <text x="140" y="85" text-anchor="middle" font-size="22" fill="#93c5fd" font-weight="bold">5 min</text>
+    <text x="140" y="105" text-anchor="middle" font-size="12" fill="#64748b">default</text>
+
+    <!-- Multiplier badge -->
+    <rect x="90" y="118" width="100" height="30" rx="15" fill="#3b82f6" opacity="0.2"/>
+    <text x="140" y="139" text-anchor="middle" font-size="16" fill="#93c5fd" font-weight="bold">1.25x</text>
+
+    <!-- API hint -->
+    <rect x="40" y="162" width="200" height="24" rx="4" fill="#0f172a"/>
+    <text x="140" y="179" text-anchor="middle" font-size="11" fill="#64748b" font-family="monospace">{ "type": "ephemeral" }</text>
+
+    <!-- Break-even -->
+    <text x="140" y="212" text-anchor="middle" font-size="11" fill="#94a3b8">Break-even:</text>
+    <text x="140" y="234" text-anchor="middle" font-size="18" fill="#22c55e" font-weight="bold">1 read</text>
+
+    <line x1="30" y1="252" x2="250" y2="252" stroke="#334155" stroke-width="1"/>
+
+    <!-- Use cases -->
+    <text x="140" y="274" text-anchor="middle" font-size="10" fill="#64748b">Best for</text>
+    <g transform="translate(30, 286)">
+      <circle cx="6" cy="6" r="3" fill="#3b82f6" opacity="0.6"/>
+      <text x="16" y="10" font-size="10" fill="#94a3b8">Conversational agents</text>
+    </g>
+    <g transform="translate(30, 306)">
+      <circle cx="6" cy="6" r="3" fill="#3b82f6" opacity="0.6"/>
+      <text x="16" y="10" font-size="10" fill="#94a3b8">Bursty, unpredictable traffic</text>
+    </g>
+  </g>
+
+  <!-- VS divider — centered between boxes: x = (70+280 + 450)/2 = (350+450)/2 = 400
+       y = 95 + 330/2 = 260 -->
+  <g transform="translate(400, 260)">
+    <circle cx="0" cy="0" r="20" fill="#334155" stroke="#475569" stroke-width="1.5"/>
+    <text x="0" y="5" text-anchor="middle" font-size="12" fill="#94a3b8" font-weight="bold">vs</text>
+  </g>
+
+  <!-- 1-hour tier (right) -->
+  <g transform="translate(450, 95)">
+    <rect width="280" height="330" rx="12" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+
+    <!-- Clock icon (longer hand) -->
+    <g transform="translate(120, 25)">
+      <circle cx="20" cy="20" r="18" fill="none" stroke="#f59e0b" stroke-width="2.5"/>
+      <line x1="20" y1="20" x2="20" y2="9" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="20" y1="20" x2="10" y2="27" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="20" cy="20" r="2.5" fill="#f59e0b"/>
+      <path d="M38,20 A18,18 0 1,1 20,2" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="3,3" opacity="0.4"/>
+    </g>
+
+    <text x="140" y="85" text-anchor="middle" font-size="22" fill="#fcd34d" font-weight="bold">1 hour</text>
+    <text x="140" y="105" text-anchor="middle" font-size="12" fill="#64748b">opt-in via ttl</text>
+
+    <!-- Multiplier badge -->
+    <rect x="100" y="118" width="80" height="30" rx="15" fill="#f59e0b" opacity="0.2"/>
+    <text x="140" y="139" text-anchor="middle" font-size="16" fill="#fcd34d" font-weight="bold">2x</text>
+
+    <!-- API hint -->
+    <rect x="18" y="162" width="244" height="24" rx="4" fill="#0f172a"/>
+    <text x="140" y="179" text-anchor="middle" font-size="10" fill="#64748b" font-family="monospace">{ "type": "ephemeral", "ttl": "1h" }</text>
+
+    <!-- Break-even -->
+    <text x="140" y="212" text-anchor="middle" font-size="11" fill="#94a3b8">Break-even:</text>
+    <text x="140" y="234" text-anchor="middle" font-size="18" fill="#22c55e" font-weight="bold">2 reads</text>
+
+    <line x1="30" y1="252" x2="250" y2="252" stroke="#334155" stroke-width="1"/>
+
+    <!-- Use cases -->
+    <text x="140" y="274" text-anchor="middle" font-size="10" fill="#64748b">Best for</text>
+    <g transform="translate(30, 286)">
+      <circle cx="6" cy="6" r="3" fill="#f59e0b" opacity="0.6"/>
+      <text x="16" y="10" font-size="10" fill="#94a3b8">Stable system prompts</text>
+    </g>
+    <g transform="translate(30, 306)">
+      <circle cx="6" cy="6" r="3" fill="#f59e0b" opacity="0.6"/>
+      <text x="16" y="10" font-size="10" fill="#94a3b8">Steady production traffic</text>
+    </g>
+  </g>
+
+  <!-- Cache read footer — centered at x=400 -->
+  <g transform="translate(200, 445)">
+    <rect width="400" height="40" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="200" y="18" text-anchor="middle" font-size="11" fill="#64748b">Cache reads (both tiers)</text>
+    <text x="200" y="34" text-anchor="middle" font-size="14" fill="#86efac" font-weight="bold">0.1x base input &#8212; 90% savings per read</text>
+  </g>
+</svg>

--- a/content/posts/choosing-prompt-cache-tier.md
+++ b/content/posts/choosing-prompt-cache-tier.md
@@ -1,0 +1,206 @@
+---
+title: "Choosing Between the 5-Minute and 1-Hour Prompt Cache Tiers"
+date: 2026-05-14T03:00:00
+draft: false
+summary: "Anthropic's prompt cache offers two write tiers: 5-minute and 1-hour. The right choice depends on how often you reuse the same cached context — and getting it wrong can cost you more than skipping caching entirely."
+featureimage: /img/posts/choosing-prompt-cache-tier/featured.svg
+tags:
+- ai
+- api
+- claude
+categories:
+- Technical posts
+---
+
+Prompt caching on the Anthropic API has two write tiers.
+A default 5-minute tier, and a longer 1-hour tier.
+Both read back at the same discounted price.
+
+The decision is not whether to cache.
+It is how long to keep the cache alive — and that decision is paid for upfront, on the write side.
+
+"Longer is better" is the easy assumption — but it is not, and the break-even math is worth knowing before committing to either tier.
+
+The official numbers from the [pricing page](https://platform.claude.com/docs/en/docs/about-claude/pricing) and the [prompt caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching):
+
+| Cache operation | Multiplier | Duration |
+| :-------------- | :--------- | :------- |
+| 5-minute write | 1.25x base input | 5 minutes |
+| 1-hour write | 2x base input | 1 hour |
+| Cache read (hit) | 0.1x base input | Same window as the preceding write |
+
+The read price is the same regardless of which tier wrote the cache.
+Only the write side differs.
+
+## The math behind the two tiers
+
+Prices per million tokens for the latest models:
+
+| Operation | Opus 4.7 | Sonnet 4.6 | Haiku 4.5 |
+| :-------- | -------: | ---------: | --------: |
+| Base input | $5.00 | $3.00 | $1.00 |
+| 5m cache write | $6.25 | $3.75 | $1.25 |
+| 1h cache write | $10.00 | $6.00 | $2.00 |
+| Cache read | $0.50 | $0.30 | $0.10 |
+
+Multipliers are identical across models — only the absolute numbers shift.
+
+The 5-minute write costs 25% more than base input.
+The 1-hour write costs 100% more.
+A cache read costs 90% less than base input on either tier.
+
+The only question is how many reads you get inside the window.
+
+![Cumulative cost comparison between no caching, 5-minute cache, and 1-hour cache](/img/posts/choosing-prompt-cache-tier/break-even.svg)
+
+## Break-even analysis
+
+Every cache read saves you 90% of the base input price.
+The write premium is what you pay upfront for those savings.
+
+**5-minute tier.** A 25% write premium. One read saves 90% — already past break-even. **Break-even: 1 read.**
+
+**1-hour tier.** A 100% write premium. Two reads recover the extra cost. **Break-even: 2 reads.**
+
+After break-even, every additional read saves the same 90% on both tiers.
+The 0.75x gap between them is fixed by the write premium and never closes — but it also stops growing.
+The real question is how long you have to accumulate those reads.
+
+| Reads within window | 5m total cost | 1h total cost | No caching |
+| :------------------ | ------------: | ------------: | ---------: |
+| 0 (write only) | 1.25x | 2.00x | 1.00x |
+| 1 | 1.35x | 2.10x | 2.00x |
+| 2 | 1.45x | 2.20x | 3.00x |
+| 3 | 1.55x | 2.30x | 4.00x |
+| 5 | 1.75x | 2.50x | 6.00x |
+| 10 | 2.25x | 3.00x | 11.00x |
+
+Costs expressed as multiples of the base input price for the cached token block. "No caching" means paying full input price on every call.
+
+## When to use each tier
+
+**Use the 5-minute tier when:**
+
+- Requests come in quick bursts — multiple calls within seconds or minutes
+- You are building conversational agents where each turn reuses the system prompt
+- Your traffic is unpredictable — short windows mean less wasted cache if traffic stops
+
+**Use the 1-hour tier when:**
+
+- You have a large, stable system prompt that many requests share over time
+- You are running a production API with steady traffic against the same context
+- Your batch jobs process many items against the same few-shot prompt
+- Agentic workflows where individual steps can exceed 5 minutes between cache hits
+
+**Do not cache at all when:**
+
+- Each request has a unique prompt with no reusable prefix
+- You make a single call and never reuse the context
+- The cacheable portion is small relative to the unique portion
+
+## Combining tiers with the Batch API
+
+Cache pricing stacks with the Batch API 50% discount. On Opus 4.7:
+
+| Opus 4.7 scenario | Input cost per MTok |
+| :----------------- | ------------------: |
+| Standard input | $5.00 |
+| Batch input (no cache) | $2.50 |
+| Cache read (standard) | $0.50 |
+| Cache read (batch) | $0.25 |
+| 5m write (batch) | $3.125 |
+| 1h write (batch) | $5.00 |
+
+With batch processing, the 1-hour cache write costs the same as a standard input call without caching.
+Any batch job with two or more reads on the same context comes out ahead.
+
+## How to enable each tier
+
+Caching is controlled by `cache_control` on content blocks.
+The type is always `"ephemeral"` — the tier is set by the `ttl` field.
+
+**5-minute cache** (default — omit `ttl`, or set it to `"5m"`):
+
+```json
+{
+  "type": "text",
+  "text": "Your system prompt here...",
+  "cache_control": { "type": "ephemeral" }
+}
+```
+
+**1-hour cache** — add `"ttl": "1h"`:
+
+```json
+{
+  "type": "text",
+  "text": "Your system prompt here...",
+  "cache_control": { "type": "ephemeral", "ttl": "1h" }
+}
+```
+
+You can mix tiers in the same request, with one constraint from the docs: **longer TTLs must appear before shorter ones**.
+Cache the stable system prompt at 1 hour, the growing conversation history at 5 minutes:
+
+```json
+{
+  "model": "claude-opus-4-7",
+  "system": [
+    {
+      "type": "text",
+      "text": "A large, stable system prompt...",
+      "cache_control": { "type": "ephemeral", "ttl": "1h" }
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "Previous conversation context...",
+          "cache_control": { "type": "ephemeral" }
+        },
+        {
+          "type": "text",
+          "text": "What should we do next?"
+        }
+      ]
+    }
+  ]
+}
+```
+
+A few practical limits worth knowing:
+
+- Up to **4 explicit cache breakpoints** per request
+- Minimum cacheable length of **1024–4096 tokens**, depending on model
+- Cache hits require **100% identical** prompt prefixes — any drift, even whitespace, invalidates the entry
+
+The response `usage` object breaks cache activity down per tier via `ephemeral_5m_input_tokens` and `ephemeral_1h_input_tokens` inside `cache_creation`.
+Useful for confirming the cache is being hit, not just written.
+
+## A practical decision framework
+
+![Decision flowchart for choosing between cache tiers](/img/posts/choosing-prompt-cache-tier/decision-flow.svg)
+
+Three questions, in order:
+
+1. **What is the reuse window?**
+   Any reuse within 5 minutes: the 5-minute tier wins.
+   Reuse spread over more than 5 minutes but inside an hour: the 1-hour tier wins, provided you get at least two reads (its break-even).
+
+2. **How stable is the context?**
+   A system prompt that never changes is a 1-hour candidate.
+   A conversation history that grows each turn works better at 5 minutes — new content invalidates the cache anyway.
+
+3. **What happens if the cache expires unused?**
+   A 5-minute write that expires wastes 25% of the base price.
+   A 1-hour write that expires wastes 100%.
+   Bursty or unpredictable traffic favors the smaller downside.
+
+For most interactive use cases — chatbots, coding assistants, agent loops — the 5-minute tier is the right default.
+The 1-hour tier earns its keep in production pipelines where the same context serves many requests over a sustained period, or in agentic workflows where individual steps run long.
+
+The two tiers solve different problems.
+Pick the one that matches your traffic shape, not the one that looks cheaper on the write line.


### PR DESCRIPTION
Compares Anthropic's 5-minute and 1-hour prompt cache write tiers with break-even math, decision flow, and tier-selection guidance. Includes featured, break-even, and decision-flow SVG illustrations.