### PR TITLE
Add Project'folio page showcasing GitHub projects as cards

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -75,3 +75,108 @@
   background-color: rgba(59, 130, 246, 0.25);
   color: rgb(96, 165, 250);
 }
+
+/* Project'folio — card grid for the /projects page */
+.projectfolio-world {
+  margin-top: 2.5rem;
+}
+
+.projectfolio-world-desc {
+  margin-top: 0.25rem;
+  color: var(--color-neutral-500);
+}
+
+.projectfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.projectfolio-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--color-neutral-200);
+  border-radius: 0.5rem;
+  background-color: var(--color-neutral-50);
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.projectfolio-card:hover {
+  border-color: var(--color-primary-400);
+  transform: translateY(-2px);
+}
+
+.dark .projectfolio-card {
+  border-color: var(--color-neutral-700);
+  background-color: var(--color-neutral-800);
+}
+
+.projectfolio-card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+.projectfolio-card-title a {
+  text-decoration: none;
+}
+
+.projectfolio-card-desc {
+  margin: 0;
+  flex-grow: 1;
+  font-size: 0.9rem;
+  color: var(--color-neutral-600);
+}
+
+.dark .projectfolio-card-desc {
+  color: var(--color-neutral-300);
+}
+
+.projectfolio-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: auto;
+}
+
+.projectfolio-lang,
+.projectfolio-tag {
+  display: inline-block;
+  font-size: 0.7em;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 0.25rem;
+  line-height: 1.2;
+}
+
+.projectfolio-lang {
+  background-color: rgba(99, 102, 241, 0.15);
+  color: rgb(79, 70, 229);
+}
+
+.dark .projectfolio-lang {
+  background-color: rgba(99, 102, 241, 0.3);
+  color: rgb(165, 180, 252);
+}
+
+.projectfolio-tag {
+  background-color: rgba(128, 128, 128, 0.15);
+  color: var(--color-neutral-500);
+}
+
+.dark .projectfolio-tag {
+  background-color: rgba(128, 128, 128, 0.25);
+  color: rgba(200, 200, 200, 0.8);
+}
+
+.projectfolio-repo {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -114,6 +114,25 @@
   background-color: var(--color-neutral-800);
 }
 
+.projectfolio-cover {
+  display: block;
+  margin: -1rem -1rem 0.25rem;
+  overflow: hidden;
+  border-radius: 0.5rem 0.5rem 0 0;
+}
+
+.projectfolio-cover img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 2 / 1;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.projectfolio-card:hover .projectfolio-cover img {
+  transform: scale(1.03);
+}
+
 .projectfolio-card-title {
   margin: 0;
   font-size: 1.05rem;

--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -6,6 +6,11 @@
   weight = 10
 
 [[main]]
+  name = "Projects"
+  pageRef = "projects"
+  weight = 20
+
+[[main]]
   name = "Series"
   pageRef = "series"
   weight = 30

--- a/content/about.md
+++ b/content/about.md
@@ -11,56 +11,11 @@ showTableOfContents: false
 
 This blog is itself [a project based on Hugo](https://github.com/rlespinasse/rlespinasse.github.io) with some GitHub Actions to automate it.
 
-In terms of automation, I play with **GitHub Actions**
+I build and maintain a range of open-source projects — **GitHub Actions**, Draw.io
+tooling, Rust utilities, interactive maps, and a few fun side projects. They're all
+showcased, grouped by world, in my [Project'folio](/projects).
 
-* to ease the release of a repository: [release-that](https://github.com/marketplace/actions/release-that),
-* to `slug` some environment variables: [github-slug-action](https://github.com/marketplace/actions/github-slug-action),
-* to `slug` any variable: [slugify-value](https://github.com/marketplace/actions/slugify-value),
-* to `short` some Git references: [shortify-git-revision](https://github.com/rlespinasse/shortify-git-revision),
-* to expose some Git commit data: [git-commit-data-action](https://github.com/marketplace/actions/git-commit-data),
-* to export Draw.io diagrams: [drawio-export-action](https://github.com/rlespinasse/drawio-export-action),
-* and a collection of reusable workflows and actions: [github-actions-toolbox](https://github.com/rlespinasse/github-actions-toolbox),
-* to substitute environment variables in files: [envsubst-action](https://github.com/actions-able/envsubst-action).
-
-And a maintained fork of the curated list of awesome actions: [awesome-actions](https://github.com/actions-able/awesome-actions).
-
-And a group of repositories dedicated to Draw.io diagrams exports
-
-* [docker-drawio-desktop-headless](https://github.com/rlespinasse/docker-drawio-desktop-headless): Docker image to serve Draw.io Desktop in a headless version,
-* [drawio-exporter](https://github.com/rlespinasse/drawio-exporter): Export Draw.io diagrams using the command line,
-* [drawio-export](https://github.com/rlespinasse/drawio-export): Export Draw.io diagrams using Docker,
-* [drawio-export-action](https://github.com/rlespinasse/drawio-export-action): Export Draw.io diagrams within GitHub Actions Workflow.
-
-In the `rust` world,
-
-* **W**hat **I** **N**eed **T**o **S**ee ([wints](https://github.com/rlespinasse/wints)), a fuzzy term-based URLs opener,
-* [drawio-exporter](https://github.com/rlespinasse/drawio-exporter) to export Draw.io diagrams using the command line.
-
-In the **tools** world,
-
-* [agent-skills](https://github.com/rlespinasse/agent-skills): Skills for AI agents,
-* [textlint-rule-link-title-case](https://github.com/rlespinasse/textlint-rule-link-title-case): A textlint rule to check link title case,
-* [homebrew-tap](https://github.com/rlespinasse/homebrew-tap): Homebrew tap for installing my tools and utilities.
-
-In the **geospatial** world,
-
-* [bassin-minier-unesco](https://github.com/rlespinasse/bassin-minier-unesco): Interactive map of the UNESCO Mining Basin,
-* [leaflet-atlas](https://github.com/rlespinasse/leaflet-atlas): Atlas powered by Leaflet.js,
-* [morvan](https://github.com/rlespinasse/morvan): Interactive map of Parc du Morvan.
-
-In the **fun** world,
-
-* [le-petit-coloriste](https://github.com/rlespinasse/le-petit-coloriste): Google Gemini gem to generate AI coloring pages for kids,
-* [le-petit-aquarium-du-marais](https://github.com/rlespinasse/le-petit-aquarium-du-marais): Collaborative aquarium filled with fish drawings by children,
-* [wraas](https://github.com/wraas/wraas.github.io): We Rickroll Absolutely Anyone, Seriously,
-* [digital-twin-product](https://github.com/wraas/digital-twin-product): Weighted Romain Algorithmic Approximation Software.
-
-In the **BriqueParBrique** world,
-
-* [BriqueParBrique](https://github.com/BriqueParBrique/BriqueParBrique.github.io): The BriqueParBrique site,
-* [nouvelle-brique](https://github.com/BriqueParBrique/nouvelle-brique): Template to start a new brique.
-
-And all my current and past projects are available on [https://github.com/rlespinasse](https://github.com/rlespinasse).
+And all my current and past projects are available on [my GitHub profile](https://github.com/rlespinasse).
 
 > You can also `sponsor me` on GitHub if you want.
 >

--- a/content/projects.md
+++ b/content/projects.md
@@ -1,0 +1,14 @@
+---
+title: "Project'folio"
+date: "2026-06-30"
+showTableOfContents: false
+showReadingTime: false
+showDate: false
+showAuthor: false
+---
+
+A curated portfolio of my GitHub projects, grouped by world — from GitHub Actions
+to interactive maps. Each card links to the project; the small **GitHub** link
+points to its repository.
+
+{{< projectfolio >}}

--- a/data/projects.toml
+++ b/data/projects.toml
@@ -1,0 +1,226 @@
+# Project'folio data — manual source of truth for the /projects page.
+# Edit this file to add, remove or reorder projects. Fields per project:
+#   name        (required) display name
+#   repo        (required) "owner/name" — used for the GitHub link
+#   url         (required) primary link (Marketplace when available, else repo)
+#   description (required) one-line description
+#   language    (optional) shown as a small badge, e.g. "Rust", "Docker"
+#   tags        (optional) list of extra labels
+#   featured    (optional) true to highlight (reserved for future use)
+
+[[worlds]]
+name = "GitHub Actions"
+description = "Automation building blocks for GitHub workflows."
+
+  [[worlds.projects]]
+  name = "release-that"
+  repo = "rlespinasse/release-that"
+  url = "https://github.com/marketplace/actions/release-that"
+  description = "Ease the release of a repository."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "github-slug-action"
+  repo = "rlespinasse/github-slug-action"
+  url = "https://github.com/marketplace/actions/github-slug-action"
+  description = "Slug some environment variables."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "slugify-value"
+  repo = "rlespinasse/slugify-value"
+  url = "https://github.com/marketplace/actions/slugify-value"
+  description = "Slug any variable."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "shortify-git-revision"
+  repo = "rlespinasse/shortify-git-revision"
+  url = "https://github.com/rlespinasse/shortify-git-revision"
+  description = "Short some Git references."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "git-commit-data-action"
+  repo = "rlespinasse/git-commit-data-action"
+  url = "https://github.com/marketplace/actions/git-commit-data"
+  description = "Expose some Git commit data."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "drawio-export-action"
+  repo = "rlespinasse/drawio-export-action"
+  url = "https://github.com/rlespinasse/drawio-export-action"
+  description = "Export Draw.io diagrams within a GitHub Actions workflow."
+  tags = ["github-actions", "drawio"]
+
+  [[worlds.projects]]
+  name = "github-actions-toolbox"
+  repo = "rlespinasse/github-actions-toolbox"
+  url = "https://github.com/rlespinasse/github-actions-toolbox"
+  description = "A collection of reusable workflows and actions."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "envsubst-action"
+  repo = "actions-able/envsubst-action"
+  url = "https://github.com/actions-able/envsubst-action"
+  description = "Substitute environment variables in files."
+  tags = ["github-actions"]
+
+  [[worlds.projects]]
+  name = "awesome-actions"
+  repo = "actions-able/awesome-actions"
+  url = "https://github.com/actions-able/awesome-actions"
+  description = "A maintained fork of the curated list of awesome actions."
+  tags = ["github-actions", "awesome-list"]
+
+[[worlds]]
+name = "Draw.io Export"
+description = "A group of repositories dedicated to Draw.io diagram exports."
+
+  [[worlds.projects]]
+  name = "docker-drawio-desktop-headless"
+  repo = "rlespinasse/docker-drawio-desktop-headless"
+  url = "https://github.com/rlespinasse/docker-drawio-desktop-headless"
+  description = "Docker image to serve Draw.io Desktop in a headless version."
+  language = "Docker"
+  tags = ["drawio"]
+
+  [[worlds.projects]]
+  name = "drawio-exporter"
+  repo = "rlespinasse/drawio-exporter"
+  url = "https://github.com/rlespinasse/drawio-exporter"
+  description = "Export Draw.io diagrams using the command line."
+  language = "Rust"
+  tags = ["drawio", "cli"]
+
+  [[worlds.projects]]
+  name = "drawio-export"
+  repo = "rlespinasse/drawio-export"
+  url = "https://github.com/rlespinasse/drawio-export"
+  description = "Export Draw.io diagrams using Docker."
+  language = "Docker"
+  tags = ["drawio"]
+
+  [[worlds.projects]]
+  name = "drawio-export-action"
+  repo = "rlespinasse/drawio-export-action"
+  url = "https://github.com/rlespinasse/drawio-export-action"
+  description = "Export Draw.io diagrams within a GitHub Actions workflow."
+  tags = ["drawio", "github-actions"]
+
+[[worlds]]
+name = "Rust"
+description = "Tools crafted in Rust."
+
+  [[worlds.projects]]
+  name = "wints"
+  repo = "rlespinasse/wints"
+  url = "https://github.com/rlespinasse/wints"
+  description = "What I Need To See — a fuzzy term-based URLs opener."
+  language = "Rust"
+  tags = ["cli"]
+
+  [[worlds.projects]]
+  name = "drawio-exporter"
+  repo = "rlespinasse/drawio-exporter"
+  url = "https://github.com/rlespinasse/drawio-exporter"
+  description = "Export Draw.io diagrams using the command line."
+  language = "Rust"
+  tags = ["cli", "drawio"]
+
+[[worlds]]
+name = "Tools"
+description = "Utilities to make everyday work smoother."
+
+  [[worlds.projects]]
+  name = "agent-skills"
+  repo = "rlespinasse/agent-skills"
+  url = "https://github.com/rlespinasse/agent-skills"
+  description = "Skills for AI agents."
+  tags = ["ai"]
+
+  [[worlds.projects]]
+  name = "textlint-rule-link-title-case"
+  repo = "rlespinasse/textlint-rule-link-title-case"
+  url = "https://github.com/rlespinasse/textlint-rule-link-title-case"
+  description = "A textlint rule to check link title case."
+  tags = ["linting"]
+
+  [[worlds.projects]]
+  name = "homebrew-tap"
+  repo = "rlespinasse/homebrew-tap"
+  url = "https://github.com/rlespinasse/homebrew-tap"
+  description = "Homebrew tap for installing my tools and utilities."
+  tags = ["homebrew"]
+
+[[worlds]]
+name = "Geospatial"
+description = "Interactive maps and atlases."
+
+  [[worlds.projects]]
+  name = "bassin-minier-unesco"
+  repo = "rlespinasse/bassin-minier-unesco"
+  url = "https://github.com/rlespinasse/bassin-minier-unesco"
+  description = "Interactive map of the UNESCO Mining Basin."
+  tags = ["maps", "leaflet"]
+
+  [[worlds.projects]]
+  name = "leaflet-atlas"
+  repo = "rlespinasse/leaflet-atlas"
+  url = "https://github.com/rlespinasse/leaflet-atlas"
+  description = "Atlas powered by Leaflet.js."
+  tags = ["maps", "leaflet"]
+
+  [[worlds.projects]]
+  name = "morvan"
+  repo = "rlespinasse/morvan"
+  url = "https://github.com/rlespinasse/morvan"
+  description = "Interactive map of Parc du Morvan."
+  tags = ["maps", "leaflet"]
+
+[[worlds]]
+name = "Fun"
+description = "Side projects made seriously, for fun."
+
+  [[worlds.projects]]
+  name = "le-petit-coloriste"
+  repo = "rlespinasse/le-petit-coloriste"
+  url = "https://github.com/rlespinasse/le-petit-coloriste"
+  description = "Google Gemini gem to generate AI coloring pages for kids."
+  tags = ["ai"]
+
+  [[worlds.projects]]
+  name = "le-petit-aquarium-du-marais"
+  repo = "rlespinasse/le-petit-aquarium-du-marais"
+  url = "https://github.com/rlespinasse/le-petit-aquarium-du-marais"
+  description = "Collaborative aquarium filled with fish drawings by children."
+
+  [[worlds.projects]]
+  name = "wraas"
+  repo = "wraas/wraas.github.io"
+  url = "https://github.com/wraas/wraas.github.io"
+  description = "We Rickroll Absolutely Anyone, Seriously."
+
+  [[worlds.projects]]
+  name = "digital-twin-product"
+  repo = "wraas/digital-twin-product"
+  url = "https://github.com/wraas/digital-twin-product"
+  description = "Weighted Romain Algorithmic Approximation Software."
+
+[[worlds]]
+name = "BriqueParBrique"
+description = "The BriqueParBrique universe."
+
+  [[worlds.projects]]
+  name = "BriqueParBrique"
+  repo = "BriqueParBrique/BriqueParBrique.github.io"
+  url = "https://github.com/BriqueParBrique/BriqueParBrique.github.io"
+  description = "The BriqueParBrique site."
+
+  [[worlds.projects]]
+  name = "nouvelle-brique"
+  repo = "BriqueParBrique/nouvelle-brique"
+  url = "https://github.com/BriqueParBrique/nouvelle-brique"
+  description = "Template to start a new brique."

--- a/data/projects.toml
+++ b/data/projects.toml
@@ -7,6 +7,10 @@
 #   language    (optional) shown as a small badge, e.g. "Rust", "Docker"
 #   tags        (optional) list of extra labels
 #   featured    (optional) true to highlight (reserved for future use)
+#   image       (optional) cover image for the card:
+#                 - omitted        -> no cover, text-only card (default)
+#                 - "github"       -> the repo's GitHub social preview card
+#                 - "/img/..." or a full URL -> used as-is
 
 [[worlds]]
 name = "GitHub Actions"
@@ -25,6 +29,7 @@ description = "Automation building blocks for GitHub workflows."
   url = "https://github.com/marketplace/actions/github-slug-action"
   description = "Slug some environment variables."
   tags = ["github-actions"]
+  image = "github"
 
   [[worlds.projects]]
   name = "slugify-value"
@@ -179,6 +184,7 @@ description = "Interactive maps and atlases."
   url = "https://github.com/rlespinasse/morvan"
   description = "Interactive map of Parc du Morvan."
   tags = ["maps", "leaflet"]
+  image = "github"
 
 [[worlds]]
 name = "Fun"
@@ -190,6 +196,7 @@ description = "Side projects made seriously, for fun."
   url = "https://github.com/rlespinasse/le-petit-coloriste"
   description = "Google Gemini gem to generate AI coloring pages for kids."
   tags = ["ai"]
+  image = "github"
 
   [[worlds.projects]]
   name = "le-petit-aquarium-du-marais"

--- a/layouts/shortcodes/projectfolio.html
+++ b/layouts/shortcodes/projectfolio.html
@@ -1,0 +1,26 @@
+{{- /* Project'folio — renders site.Data.projects as card grids grouped by world. */ -}}
+{{- with hugo.Data.projects.worlds -}}
+  {{- range . -}}
+    <section class="projectfolio-world">
+      <h2 id="{{ .name | urlize }}">{{ .name }}</h2>
+      {{- with .description }}<p class="projectfolio-world-desc">{{ . }}</p>{{ end -}}
+      <div class="projectfolio-grid">
+        {{- range .projects -}}
+          <article class="projectfolio-card">
+            <h3 class="projectfolio-card-title">
+              <a href="{{ .url }}" rel="noopener">{{ .name }}</a>
+            </h3>
+            <p class="projectfolio-card-desc">{{ .description }}</p>
+            <div class="projectfolio-meta">
+              {{- with .language }}<span class="projectfolio-lang">{{ . }}</span>{{ end -}}
+              {{- range .tags }}<span class="projectfolio-tag">{{ . }}</span>{{ end -}}
+              <a class="projectfolio-repo" href="https://github.com/{{ .repo }}" rel="noopener">GitHub&nbsp;↗</a>
+            </div>
+          </article>
+        {{- end -}}
+      </div>
+    </section>
+  {{- end -}}
+{{- else -}}
+  {{- warnf "projectfolio: no data found at data/projects.toml" -}}
+{{- end -}}

--- a/layouts/shortcodes/projectfolio.html
+++ b/layouts/shortcodes/projectfolio.html
@@ -6,7 +6,17 @@
       {{- with .description }}<p class="projectfolio-world-desc">{{ . }}</p>{{ end -}}
       <div class="projectfolio-grid">
         {{- range .projects -}}
+          {{- $project := . -}}
           <article class="projectfolio-card">
+            {{- with .image -}}
+              {{- $src := . -}}
+              {{- if eq . "github" -}}
+                {{- $src = printf "https://opengraph.githubassets.com/%s/%s" ($project.repo | crypto.MD5) $project.repo -}}
+              {{- end -}}
+              <a class="projectfolio-cover" href="{{ $project.url }}" rel="noopener">
+                <img src="{{ $src }}" alt="{{ $project.name }} cover" loading="lazy" decoding="async">
+              </a>
+            {{- end -}}
             <h3 class="projectfolio-card-title">
               <a href="{{ .url }}" rel="noopener">{{ .name }}</a>
             </h3>


### PR DESCRIPTION
Introduce a dedicated /projects page rendering a card gallery of
open-source projects grouped by "world" (GitHub Actions, Draw.io,
Rust, tools, geospatial, fun, BriqueParBrique).

- data/projects.toml: manual source of truth for the project list
- layouts/shortcodes/projectfolio.html: renders the card grid
- content/projects.md: the Project'folio page
- menus.en.toml: add "Projects" entry to the main menu
- about.md: replace the bullet lists with a link to the new page
- custom.css: card grid styles with light/dark support

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VpEtKwrVGWo32Tn3nKyfS4